### PR TITLE
Fixes new generic function issue

### DIFF
--- a/CleanupUtility/Plugin.cs
+++ b/CleanupUtility/Plugin.cs
@@ -35,7 +35,7 @@ namespace CleanupUtility
         public override Version RequiredExiledVersion { get; } = new(8, 0, 0);
 
         /// <inheritdoc />
-        public override Version Version { get; } = new(2, 0, 5);
+        public override Version Version { get; } = new(2, 0, 6);
 
         /// <summary>
         /// Gets an instance of the <see cref="PickupChecker"/> class.


### PR DESCRIPTION
Apparently Exiled decided to make ItemPickupBase have two functions, one generic and one non-generic which broke this.